### PR TITLE
Fix 'unknown instruction'Dockerfile parsing exception

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN useradd -m -s /bin/bash openmodelicausers
 # Copy the kernel from root location to non root location so that jupyter notebook when started as non-root can find openmodelica kernel
 RUN cp -R /root/.local/share/jupyter/kernels/OpenModelica /usr/local/share/jupyter/kernels/
 
-Get Dygraph for plotting in OM notebook
+# Get Dygraph for plotting in OM notebook
 WORKDIR /home/openmodelicausers
 RUN apt-get install -y curl && curl -O https://cdnjs.cloudflare.com/ajax/libs/dygraph/1.0.1/dygraph-combined.js
 


### PR DESCRIPTION
Command Fails with message:
```
$ docker build --tag opendce:latest .
[+] Building 0.1s (2/2) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                            0.0s
 => => transferring dockerfile: 37B                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                                 0.0s
failed to solve with frontend dockerfile.v0: failed to create LLB definition: dockerfile parse error line 33: unknown instruction: GET
```